### PR TITLE
docs: README 하이퍼링크를 절대 경로로 변경

### DIFF
--- a/profile/README.en-US.md
+++ b/profile/README.en-US.md
@@ -21,7 +21,7 @@
 
 </div>
 
-[한국어(KR)](./README.md) | [`English`](./README.en-US.md)
+[한국어(KR)](./README.md) | [`English`](/profile/README.en-US.md)
 
 <p>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,7 @@
 
 </div>
 
-[`한국어(KR)`](./README.md) | [English](./README.en-US.md)
+[`한국어(KR)`](./README.md) | [English](/profile/README.en-US.md)
 
 <p>
 


### PR DESCRIPTION
## 원인

`영문 README` 파일이 추가된 뒤 `Dashboard` 에서 아래와 같이 접근 시 링크가 깨지는 현상이 발생했습니다.

<img width="923" alt="스크린샷 2023-05-01 22 23 41" src="https://user-images.githubusercontent.com/63892989/235458239-bf515249-ef91-4ce3-8f8f-c1ea58b9eb43.png">

<img width="1427" alt="스크린샷 2023-05-01 22 24 34" src="https://user-images.githubusercontent.com/63892989/235458246-6a001b85-c1aa-4216-953e-07259307c378.png">


## 처리

문제를 해결하기 위해서 `하이퍼링크` 를 `절대 경로` 로 변경합니다.